### PR TITLE
fix: tsconfig

### DIFF
--- a/apps/hr/src/pages/_app.tsx
+++ b/apps/hr/src/pages/_app.tsx
@@ -7,7 +7,7 @@ import {appWithTranslation, useTranslation} from 'next-i18next';
 import React from 'react';
 
 import nextI18NextConfig from '../../next-i18next.config';
-import {Footer, Header} from '../components/';
+import {Footer, Header} from '../components/index';
 import {createEmotionCache} from '../helpers/createEmotionCache';
 import {GA_MEASUREMENT_ID, pageview} from '../helpers/gtag';
 import {withYM, YA_METRIKA_ID} from '../helpers/ym';

--- a/apps/hr/src/pages/_app.tsx
+++ b/apps/hr/src/pages/_app.tsx
@@ -7,7 +7,7 @@ import {appWithTranslation, useTranslation} from 'next-i18next';
 import React from 'react';
 
 import nextI18NextConfig from '../../next-i18next.config';
-import {Footer, Header} from '../components/index';
+import {Footer, Header} from '../components/';
 import {createEmotionCache} from '../helpers/createEmotionCache';
 import {GA_MEASUREMENT_ID, pageview} from '../helpers/gtag';
 import {withYM, YA_METRIKA_ID} from '../helpers/ym';

--- a/packages/tsconfig/nextjs.json
+++ b/packages/tsconfig/nextjs.json
@@ -3,6 +3,7 @@
   "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Updated TypeScript configuration to allow importing `.ts` extensions.

- Fixed import path in `_app.tsx` for consistency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_app.tsx</strong><dd><code>Fix import path in `_app.tsx`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/hr/src/pages/_app.tsx

<li>Fixed import path for <code>Footer</code> and <code>Header</code> components.<br> <li> Ensured consistency in import statements.


</details>


  </td>
  <td><a href="https://github.com/magickasoft/evgart/pull/218/files#diff-84b2c489b2abf27788862f9c5d361c5ec9c7ad09d20cb3fb9fcb7c1a678fbb1a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nextjs.json</strong><dd><code>Update TypeScript configuration for `.ts` imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/tsconfig/nextjs.json

<li>Added <code>allowImportingTsExtensions</code> to TypeScript configuration.<br> <li> Enhanced compatibility for <code>.ts</code> file imports.


</details>


  </td>
  <td><a href="https://github.com/magickasoft/evgart/pull/218/files#diff-e3bf761cfc994a85bb134669ef7591d44332c886c228c73236c683431bd56498">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>